### PR TITLE
Package for upload to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/*.egg-info
+/build
+/dist
+__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Hans-Wilhelm Warlo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,33 @@
+**********************************
+codemod-unittest-to-pytest-asserts
+**********************************
+
+A `codemod <https://pypi.org/project/codemod/>`_ to automatically refactor
+unittest assertions with pytest assertions.
+
+
+Installation
+============
+
+This codemod requires Python 3.8 or newer.
+
+With pip, assuming Python 3.8 or newer is used::
+
+   python3 -m pip install codemod-unittest-to-pytest-asserts
+
+With pipx, assuming Python 3.8 exists on the system::
+
+   pipx install --python $(which python3.8) codemod-unittest-to-pytest-asserts
+
+
+Usage
+=====
+
+Run the installed command on the Python files you want to refactor::
+
+   codemod-unittest-to-pytest-asserts some-python-files.py
+
+You'll be asked to confirm all changes.
+
+It is recommended to run an autoformatter, like Black, after the
+refactoring.

--- a/codemod_unittest_to_pytest_asserts.py
+++ b/codemod_unittest_to_pytest_asserts.py
@@ -318,5 +318,10 @@ def is_py(filename):
     return filename.split(".")[-1] == "py"
 
 
-codemod.Query(assert_patches, path_filter=is_py).run_interactive()
-print("\nHINT: Consider running a formatter to correctly format your new assertions!")
+def main():
+    codemod.Query(assert_patches, path_filter=is_py).run_interactive()
+    print("\nHINT: Consider running a formatter to correctly format your new assertions!")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-astunparse==1.6.2
-codemod==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,9 @@ name = codemod-unittest-to-pytest-asserts
 version = 1.0.0
 author = Hans-Wilhelm Warlo
 author_email = hw@warlo.no
-license = Apache License, Version 2.0
+license = MIT
 description = Codemod to refactor unittest assertions to pytest assertions.
+url = https://github.com/hanswilw/codemod-unittest-to-pytest-asserts
 long_description = file: README.rst
 classifiers =
     Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+[metadata]
+name = codemod-unittest-to-pytest-asserts
+version = 1.0.0
+author = Hans-Wilhelm Warlo
+author_email = hw@warlo.no
+license = Apache License, Version 2.0
+description = Codemod to refactor unittest assertions to pytest assertions.
+long_description = file: README.rst
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+
+[options]
+zip_safe = False
+include_package_data = False
+py_modules = codemod_unittest_to_pytest_asserts
+python_requires = >= 3.8
+install_requires =
+  codemod >= 1.0.0
+  astunparse >= 1.6.2
+
+[options.entry_points]
+console_scripts =
+    codemod-unittest-to-pytest-asserts = codemod_unittest_to_pytest_asserts:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
I've packaged this up for release to PyPI:

TODO left for you:

- [x] Rename to a package name you like. I've changed it to at least include "unittest" and "pytest". 
- [x] Remember to rename the repo too, and include that in `setup.cfg`, in the `[metadata]` section as the `url` to get links from PyPI back to GitHub.
- [x] Change license in `setup.cfg` to one you like.
- [x] `python setup.py sdist bdist_wheel`
- [x] `twine upload dist/*`