### PR TITLE
handle optional variables while updating assertRaises

### DIFF
--- a/codemod_unittest_to_pytest_asserts/__init__.py
+++ b/codemod_unittest_to_pytest_asserts/__init__.py
@@ -211,7 +211,7 @@ def handle_not_almost_equal(node):
 
 def handle_raises(node, **kwargs):
     if kwargs.get("withitem"):
-        return handle_with_raises(node)
+        return handle_with_raises(node, **kwargs)
     args, _ = parse_args(node)
     if len(args) > 2:
         print(f"Malformed: {node}: {astunparse.unparse(node)}\n")
@@ -220,13 +220,16 @@ def handle_raises(node, **kwargs):
         return f"pytest.raises({args[0]}, {args[1]})"
 
 
-def handle_with_raises(node):
+def handle_with_raises(node, **kwargs):
     args, _ = parse_args(node)
+    optional_vars = kwargs.get('optional_vars', None)
     if len(args) > 1:
         print(f"Malformed: {node}: {astunparse.unparse(node)}\n")
         return
-    if len(args) == 1:
-        return f"with pytest.raises({args[0]}):"
+
+    if optional_vars:
+        return f"with pytest.raises({args[0]}) as {optional_vars.id}:"
+    return f"with pytest.raises({args[0]}):"
 
 
 assert_mapping = {
@@ -263,7 +266,7 @@ def convert(node):
         return None
 
     if isinstance(node, ast.With):
-        return f(node_call, withitem=True)
+        return f(node_call, withitem=True, optional_vars=node.items[0].optional_vars)
     return f(node_call)
 
 

--- a/codemod_unittest_to_pytest_asserts/tests/pytest_code.py
+++ b/codemod_unittest_to_pytest_asserts/tests/pytest_code.py
@@ -23,3 +23,8 @@ class ExampleTest:
             assert True
 
         assert not False
+
+    def test_assert_raises(self):
+        with pytest.raises(ZeroDivisionError) as exc:
+            divide_by_zero = 3 / 0
+        assert exc.exception.args[0] == 'division by zero'

--- a/codemod_unittest_to_pytest_asserts/tests/unittest_code.py
+++ b/codemod_unittest_to_pytest_asserts/tests/unittest_code.py
@@ -28,3 +28,8 @@ class ExampleTest:
             self.assertTrue(True)
 
         self.assertFalse(False)
+
+    def test_assert_raises(self):
+        with self.assertRaises(ZeroDivisionError) as exc:
+            divide_by_zero = 3 / 0
+        self.assertEqual(exc.exception.args[0], 'division by zero')


### PR DESCRIPTION
This PR adds the ability to handle optional variables while updating `unittest`'s `assertRaises` with `pytest`'s `pytest.raises`.
currently, if we run the codemod to update the following `unittest` assertion
```
with self.assertRaises(TypeError) as context:
    # code that causes the exception
self.assertEqual(context.exception.args[0], 'verifying error message')
```
it results in
```
with pytest.raises(TypeError):
    # code that causes the exception
assert context.exception.args[0] == 'verifying error message'
```
that causes an error for `context` variable not being resolved.
with this PR, the codemod script will add the optional variable if it was used. e.g
```
with pytest.raises(TypeError) as context:
```