### PR TITLE
De-yoda equals expressions

### DIFF
--- a/codemod_unittest_to_pytest_asserts/__init__.py
+++ b/codemod_unittest_to_pytest_asserts/__init__.py
@@ -58,6 +58,10 @@ def _handle_equal_or_unequal(node, *, is_op, cmp_op):
     if args[1] in TRUE_FALSE_NONE:
         return f"assert {args[0]} {is_op} {args[1]}{msg_with_comma}"
 
+    # De-yoda expressions like assertEqual("foo", bar) to bar == "foo"
+    if node.args[0].__class__ == ast.Constant and node.args[1].__class__ != ast.Constant:
+        args = [args[1], args[0]]
+
     return f"assert {args[0]} {cmp_op} {args[1]}{msg_with_comma}"
 
 

--- a/codemod_unittest_to_pytest_asserts/tests/pytest_code.py
+++ b/codemod_unittest_to_pytest_asserts/tests/pytest_code.py
@@ -48,3 +48,7 @@ class ExampleTest:
         assert 2 <= 2
         assert 3 > 2
         assert 4 >= 3
+
+    def test_de_yoda(self):
+        foo = "baz"
+        assert foo == 'bar'

--- a/codemod_unittest_to_pytest_asserts/tests/unittest_code.py
+++ b/codemod_unittest_to_pytest_asserts/tests/unittest_code.py
@@ -53,3 +53,7 @@ class ExampleTest:
         self.assertLessEqual(2, 2)
         self.assertGreater(3, 2)
         self.assertGreaterEqual(4, 3)
+
+    def test_de_yoda(self):
+        foo = "baz"
+        self.assertEqual('bar', foo)


### PR DESCRIPTION
This PR [de-yodas conditions](https://en.wikipedia.org/wiki/Yoda_conditions) for more idiomatic Python.

With this PR,
```
self.assertEqual('bar', foo)
```
turns to
```
assert foo == 'bar'
```
, not
```
assert 'bar' == foo
```