### PR TITLE
Don't crash if a kwarg has multiple equals signs

### DIFF
--- a/codemod_unittest_to_pytest_asserts/__init__.py
+++ b/codemod_unittest_to_pytest_asserts/__init__.py
@@ -32,7 +32,7 @@ def parse_args_and_msg(node, required_args_count, *, raise_if_malformed=True):
     msg = ""
 
     for i, kwarg in enumerate(kwarg_list):
-        key, val = kwarg.split("=")
+        key, val = kwarg.split("=", 1)
         if key == "msg":
             msg = val
             kwarg_list.pop(i)


### PR DESCRIPTION
Small issue spotted in the wild ✌️ 

This is still such an useful tool two years later... 😄 